### PR TITLE
expose modules as entrypoints on install, use relative pathing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-ecephys spike sorting
-===============================
+# ecephys spike sorting
 
 https://github.com/AllenInstitute/ecephys_spike_sorting
 
 Modules for spike-sorting Allen Institute Neuropixels data
 
-
 ## Modules
+
 [extract from npx](ecephys_spike_sorting/modules/extract_from_npx/README.md): Calls a binary executable that converts data from compressed NPX format into .dat files (continuous data) and .npy files (event data)
 
 [depth estimation](ecephys_spike_sorting/modules/depth_estimation/README.md): Uses the LFP data to identify the surface channel, which is required by the median subtraction and kilosort modules.
@@ -23,5 +22,19 @@ Modules for spike-sorting Allen Institute Neuropixels data
 
 [quality metrics](ecephys_spike_sorting/modules/quality_metrics/README.md): Calculate quality metrics for each unit to assess isolation and sorting quality.
 
+## Install
 
+    $ pip install .
 
+## Entry Points
+
+Installing as a module should automagically expose the aforementioned modules using `setuptools` entry_points
+
+-   extract from npx: `extract-from-npx`
+-   depth estimation: `depth-estimation`
+-   median subtraction: `median-subtraction`
+-   kilosort helper: `kilosort-helper`
+-   noise templates: `noise_templates`
+-   automerging: `automerging`
+-   mean waveforms: `mean-waveforms`
+-   quality metrics: `quality-metrics`

--- a/ecephys_spike_sorting/modules/automerging/__main__.py
+++ b/ecephys_spike_sorting/modules/automerging/__main__.py
@@ -3,9 +3,9 @@ import os
 import logging
 import time
 
-from ecephys_spike_sorting.modules.automerging.automerging import automerging
+from .automerging import automerging
 
-from ecephys_spike_sorting.common.utils import write_cluster_group_tsv, load_kilosort_data
+from ...common.utils import write_cluster_group_tsv, load_kilosort_data
 
 
 def run_automerging(args):
@@ -31,7 +31,7 @@ def run_automerging(args):
 
 def main():
 
-    from _schemas import InputParameters, OutputParameters
+    from ._schemas import InputParameters, OutputParameters
 
     mod = ArgSchemaParser(schema_type=InputParameters,
                           output_schema_type=OutputParameters)

--- a/ecephys_spike_sorting/modules/automerging/_schemas.py
+++ b/ecephys_spike_sorting/modules/automerging/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 
 class AutomergingParams(DefaultSchema):

--- a/ecephys_spike_sorting/modules/automerging/automerging.py
+++ b/ecephys_spike_sorting/modules/automerging/automerging.py
@@ -2,9 +2,9 @@ import os
 import pandas as pd
 import numpy as np
 
-from ecephys_spike_sorting.modules.automerging.metrics import compare_templates, make_interp_temp, compute_isi_score, compute_isi_score
-from ecephys_spike_sorting.modules.automerging.merges import compute_overall_score, ID_merge_groups, make_merges
-from ecephys_spike_sorting.common.spike_template_helpers import find_depth
+from .metrics import compare_templates, make_interp_temp, compute_isi_score, compute_isi_score
+from .merges import compute_overall_score, ID_merge_groups, make_merges
+from ...common.spike_template_helpers import find_depth
 
 def automerging(spike_times, spike_clusters, clusterIDs, cluster_quality, templates, params):
 

--- a/ecephys_spike_sorting/modules/automerging/metrics.py
+++ b/ecephys_spike_sorting/modules/automerging/metrics.py
@@ -9,7 +9,7 @@ Created on Thu Feb  1 19:00:45 2018
 from scipy.interpolate import griddata
 from scipy.signal import correlate
 import numpy as np
-from ecephys_spike_sorting.modules.automerging.spike_ISI import *    
+from .spike_ISI import *    
 
 # %%
 

--- a/ecephys_spike_sorting/modules/depth_estimation/__main__.py
+++ b/ecephys_spike_sorting/modules/depth_estimation/__main__.py
@@ -5,8 +5,8 @@ import time
 
 import numpy as np
 
-from ecephys_spike_sorting.modules.depth_estimation.depth_estimation import compute_offset_and_surface_channel
-from ecephys_spike_sorting.common.utils import get_ap_band_continuous_file, get_lfp_band_continuous_file, write_probe_json
+from .depth_estimation import compute_offset_and_surface_channel
+from ...common.utils import get_ap_band_continuous_file, get_lfp_band_continuous_file, write_probe_json
 
 
 def run_depth_estimation(args):

--- a/ecephys_spike_sorting/modules/depth_estimation/_schemas.py
+++ b/ecephys_spike_sorting/modules/depth_estimation/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, NumpyArray, String, Float, Dict, Int, Bool, OutputFile
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 class DepthEstimationParams(DefaultSchema):
     hi_noise_thresh = Float(required=True, default=50.0, help='Max RMS noise for including channels')

--- a/ecephys_spike_sorting/modules/depth_estimation/depth_estimation.py
+++ b/ecephys_spike_sorting/modules/depth_estimation/depth_estimation.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from scipy.signal import welch
 from scipy.ndimage.filters import gaussian_filter1d
 
-from ecephys_spike_sorting.common.utils import find_range, rms
+from ...common.utils import find_range, rms
 
 def find_surface_channel(data, params, reference_channels, nchannels=384, sample_frequency=2500):
     

--- a/ecephys_spike_sorting/modules/extract_from_npx/__main__.py
+++ b/ecephys_spike_sorting/modules/extract_from_npx/__main__.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import io, json, os
 
-from ecephys_spike_sorting.modules.extract_from_npx.create_settings_json import create_settings_json
+from .create_settings_json import create_settings_json
 
 def run_npx_extractor(args):
 

--- a/ecephys_spike_sorting/modules/extract_from_npx/_schemas.py
+++ b/ecephys_spike_sorting/modules/extract_from_npx/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 class InputParameters(ArgSchema): 
     npx_file = String(help='Path to NPX file saved by Open Ephys')

--- a/ecephys_spike_sorting/modules/kilosort_helper/__main__.py
+++ b/ecephys_spike_sorting/modules/kilosort_helper/__main__.py
@@ -9,8 +9,8 @@ import numpy as np
 
 import matlab.engine
 
-import ecephys_spike_sorting.modules.kilosort_helper.matlab_file_generator as matlab_file_generator
-from ecephys_spike_sorting.common.utils import read_probe_json, get_ap_band_continuous_file
+from . import matlab_file_generator
+from ...common.utils import read_probe_json, get_ap_band_continuous_file
 
 def run_kilosort(args):
 

--- a/ecephys_spike_sorting/modules/kilosort_helper/_schemas.py
+++ b/ecephys_spike_sorting/modules/kilosort_helper/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 class KilosortParameters(DefaultSchema):
 

--- a/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
@@ -5,10 +5,10 @@ import time
 
 import numpy as np
 
-from ecephys_spike_sorting.common.utils import get_ap_band_continuous_file
-from ecephys_spike_sorting.common.utils import load_kilosort_data
+from ...common.utils import get_ap_band_continuous_file
+from ...common.utils import load_kilosort_data
 
-from ecephys_spike_sorting.modules.mean_waveforms.extract_waveforms import extract_waveforms, writeDataAsNpy
+from .extract_waveforms import extract_waveforms, writeDataAsNpy
 
 def calculate_mean_waveforms(args):
     

--- a/ecephys_spike_sorting/modules/mean_waveforms/_schemas.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 class MeanWaveformParams(DefaultSchema):
     samples_per_spike = Int(required=True, default=82, help='Number of samples to extract for each spike')

--- a/ecephys_spike_sorting/modules/median_subtraction/__main__.py
+++ b/ecephys_spike_sorting/modules/median_subtraction/__main__.py
@@ -9,8 +9,8 @@ from git import Repo
 
 import numpy as np
 
-from ecephys_spike_sorting.common.utils import read_probe_json
-from ecephys_spike_sorting.common.utils import get_ap_band_continuous_file
+from ...common.utils import read_probe_json
+from ...common.utils import get_ap_band_continuous_file
 
 def run_median_subtraction(args):
 

--- a/ecephys_spike_sorting/modules/median_subtraction/_schemas.py
+++ b/ecephys_spike_sorting/modules/median_subtraction/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 class InputParameters(ArgSchema): 
     probe_json = String(help='Path to probe json (saved by depth_estimation module)')

--- a/ecephys_spike_sorting/modules/noise_templates/__main__.py
+++ b/ecephys_spike_sorting/modules/noise_templates/__main__.py
@@ -3,9 +3,9 @@ import os
 import logging
 import time
 
-from ecephys_spike_sorting.modules.noise_templates.id_noise_templates import id_noise_templates_rf
+from .id_noise_templates import id_noise_templates_rf
 
-from ecephys_spike_sorting.common.utils import write_cluster_group_tsv, load_kilosort_data
+from ...common.utils import write_cluster_group_tsv, load_kilosort_data
 
 
 def classify_noise_templates(args):

--- a/ecephys_spike_sorting/modules/noise_templates/_schemas.py
+++ b/ecephys_spike_sorting/modules/noise_templates/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int, NumpyArray
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 class NoiseWaveformParams(DefaultSchema):
 	classifier_path = String(required=True, default='classifier.pkl', help='Path to waveform classifier')

--- a/ecephys_spike_sorting/modules/noise_templates/id_noise_templates.py
+++ b/ecephys_spike_sorting/modules/noise_templates/id_noise_templates.py
@@ -5,7 +5,7 @@ from sklearn.ensemble import RandomForestClassifier
 
 import pickle
 
-from ecephys_spike_sorting.common.spike_template_helpers import find_depth
+from ...common.spike_template_helpers import find_depth
 
 
 def id_noise_templates_rf(spike_times, spike_clusters, cluster_ids, templates, params):

--- a/ecephys_spike_sorting/modules/quality_metrics/__main__.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/__main__.py
@@ -6,10 +6,10 @@ import time
 import numpy as np
 import pandas as pd
 
-from ecephys_spike_sorting.common.utils import get_ap_band_continuous_file
-from ecephys_spike_sorting.common.utils import load_kilosort_data
+from ...common.utils import get_ap_band_continuous_file
+from ...common.utils import load_kilosort_data
 
-from ecephys_spike_sorting.modules.quality_metrics.metrics import calculate_metrics
+from .metrics import calculate_metrics
 
 def calculate_quality_metrics(args):
 

--- a/ecephys_spike_sorting/modules/quality_metrics/_schemas.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/_schemas.py
@@ -1,7 +1,7 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
 from argschema.fields import Nested, InputDir, String, Float, Dict, Int
-from ecephys_spike_sorting.common.schemas import EphysParams, Directories
+from ...common.schemas import EphysParams, Directories
 
 
 class QualityMetricsParams(DefaultSchema):

--- a/ecephys_spike_sorting/modules/quality_metrics/metrics.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/metrics.py
@@ -3,7 +3,7 @@ import pandas as pd
 from sklearn import decomposition, neighbors
 from collections import OrderedDict
 
-from ecephys_spike_sorting.common.spike_template_helpers import find_depth
+from ...common.spike_template_helpers import find_depth
 
 def calculate_metrics(data, spike_times, spike_clusters, amplitudes, sample_rate, params):
 

--- a/ecephys_spike_sorting/modules/quality_metrics/waveform_feature_extraction_test.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/waveform_feature_extraction_test.py
@@ -9,7 +9,7 @@ Created on Tue Feb 5 15:05:21 2019
 
 import numpy as np
 import pandas as pd
-import ecephys_spike_sorting.modules.quality_metrics.waveform_feature_extraction as wf
+import .waveform_feature_extraction as wf
 
 def get_waveforms(input_waveforms, peak_ch):
     waveforms=[]

--- a/integration-tox.ini
+++ b/integration-tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py{36}-{test}
+
+[testenv:py36-test]
+
+[testenv]
+
+commands = 
+    # package can install
+    pip install .
+    # entrypoints are exposed
+    automerging -h
+    depth-estimation -h
+    extract-from-npx -h
+    # kilosort-helper -h  # TODO: test this, requires more complex test setup due to matlab :(...
+    mean-waveforms -h
+    noise-templates -h
+    quality-metrics -h

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,28 @@ setup(
     packages = find_packages(),
     include_package_data=True,
     entry_points={
-          'console_scripts': [
-              'ecephys_spike_sorting = ecephys_spike_sorting.__main__:main'
-        ]
+        'console_scripts': [
+              'automerging = ecephys_spike_sorting.modules.automerging.__main__:main',
+              'depth-estimation = ecephys_spike_sorting.modules.depth_estimation.__main__:main',
+              'extract-from-npx = ecephys_spike_sorting.modules.extract_from_npx.__main__:main',
+              'kilosort-helper = ecephys_spike_sorting.modules.kilosort_helper.__main__:main',
+              'mean-waveforms = ecephys_spike_sorting.modules.mean_waveforms.__main__:main',
+              'median-subtraction = ecephys_spike_sorting.modules.median_subtraction.__main__:main',
+              'noise-templates = ecephys_spike_sorting.modules.noise_templates.__main__:main',
+              'quality-metrics = ecephys_spike_sorting.modules.quality_metrics.__main__:main',
+        ],
     },
     setup_requires=['pytest-runner'],
+    install_requires=[
+        'matplotlib',
+        'scipy',
+        'numpy',
+        'pandas',
+        'GitPython',
+        'pillow',
+        'argschema',
+        'xmljson',
+        'xarray',
+        'scikit-learn',
+    ],
 )


### PR DESCRIPTION
the changes we talked about, pip installing the package should now expose the modules to the terminal