### PR TITLE
Add spike_templates to load_kilosort_data

### DIFF
--- a/ecephys_spike_sorting/common/utils.py
+++ b/ecephys_spike_sorting/common/utils.py
@@ -232,7 +232,12 @@ def load(folder, filename):
     return np.load(os.path.join(folder, filename))
 
 
-def load_kilosort_data(folder, sample_rate = None, convert_to_seconds = True, use_master_clock = False, include_pcs = False, template_zero_padding= 21):
+def load_kilosort_data(folder, 
+                       sample_rate = None, 
+                       convert_to_seconds = True, 
+                       use_master_clock = False, 
+                       include_pcs = False,
+                       template_zero_padding= 21):
 
     """
     Loads Kilosort output files from a directory
@@ -258,6 +263,8 @@ def load_kilosort_data(folder, sample_rate = None, convert_to_seconds = True, us
         Times for N spikes
     spike_clusters : numpy.ndarray (N x 0)
         Cluster IDs for N spikes
+    spike_templates : numpy.ndarray (N x 0)
+        Template IDs for N spikes
     amplitudes : numpy.ndarray (N x 0)
         Amplitudes for N spikes
     unwhitened_temps : numpy.ndarray (M x samples x channels) 
@@ -281,6 +288,7 @@ def load_kilosort_data(folder, sample_rate = None, convert_to_seconds = True, us
         spike_times = load(folder,'spike_times.npy')
         
     spike_clusters = load(folder,'spike_clusters.npy')
+    spike_templates = load(folder, 'spike_templates.npy')
     amplitudes = load(folder,'amplitudes.npy')
     templates = load(folder,'templates.npy')
     unwhitening_mat = load(folder,'whitening_mat_inv.npy')
@@ -288,7 +296,7 @@ def load_kilosort_data(folder, sample_rate = None, convert_to_seconds = True, us
 
     if include_pcs:
         pc_features = load(folder, 'pc_features.npy')
-        pc_feature_ind = load(folder, 'pc_feature_ind.npy')
+        pc_feature_ind = load(folder, 'pc_feature_ind.npy') 
                 
     templates = templates[:,template_zero_padding:,:] # remove zeros
     spike_clusters = np.squeeze(spike_clusters) # fix dimensions
@@ -310,9 +318,9 @@ def load_kilosort_data(folder, sample_rate = None, convert_to_seconds = True, us
         cluster_quality = ['unsorted'] * cluster_ids.size
 
     if not include_pcs:
-        return spike_times, spike_clusters, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality
+        return spike_times, spike_clusters, spike_templates, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality
     else:
-        return spike_times, spike_clusters, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality, pc_features, pc_feature_ind
+        return spike_times, spike_clusters, spike_templates, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality, pc_features, pc_feature_ind
 
 
 def get_repo_commit_date_and_hash(repo_location):

--- a/ecephys_spike_sorting/modules/automerging/__main__.py
+++ b/ecephys_spike_sorting/modules/automerging/__main__.py
@@ -14,7 +14,7 @@ def run_automerging(args):
 
     start = time.time()
     
-    spike_times, spike_clusters, amplitudes, templates, channel_map, clusterIDs, cluster_quality = \
+    spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality = \
         load_kilosort_data(args['directories']['kilosort_output_directory'], \
             args['ephys_params']['sample_rate'], \
             convert_to_seconds = True)
@@ -26,8 +26,8 @@ def run_automerging(args):
 
     execution_time = time.time() - start
 
-    print('total time: ' + str(execution_time) + ' seconds')
-    print( )
+    print('total time: ' + str(np.around(execution_time,2)) + ' seconds')
+    print()
     
     return {"execution_time" : execution_time} # output manifest
 

--- a/ecephys_spike_sorting/modules/kilosort_postprocessing/__main__.py
+++ b/ecephys_spike_sorting/modules/kilosort_postprocessing/__main__.py
@@ -18,16 +18,17 @@ def run_postprocessing(args):
 
     start = time.time()
 
-    spike_times, spike_clusters, amplitudes, templates, channel_map, clusterIDs, cluster_quality, pc_features, pc_feature_ind = \
+    spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality, pc_features, pc_feature_ind = \
                 load_kilosort_data(args['directories']['kilosort_output_directory'], \
                     args['ephys_params']['sample_rate'], \
                     convert_to_seconds = False,
                     use_master_clock = False,
                     include_pcs = True)
 
-    spike_times, spike_clusters, amplitudes, pc_features, overlap_matrix = \
+    spike_times, spike_clusters, spike_templates, amplitudes, pc_features, overlap_matrix = \
         remove_double_counted_spikes(spike_times, 
-                                     spike_clusters, 
+                                     spike_clusters,
+                                     spike_templates, 
                                      amplitudes, 
                                      channel_map,
                                      templates, 
@@ -39,10 +40,11 @@ def run_postprocessing(args):
     print("Saving data...")
 
     # save data -- it's fine to overwrite existing files, because the original outputs are stored in rez.mat
-    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'spike_times_r.npy'), spike_times)
-    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'amplitudes_r.npy'), amplitudes)
-    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'spike_clusters_r.npy'), spike_clusters)
-    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'pc_features_r.npy'), pc_features)
+    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'spike_times.npy'), spike_times)
+    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'amplitudes.npy'), amplitudes)
+    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'spike_clusters.npy'), spike_clusters)
+    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'spike_templates.npy'), spike_templates)
+    np.save(os.path.join(args['directories']['kilosort_output_directory'], 'pc_features.npy'), pc_features)
     np.save(os.path.join(args['directories']['kilosort_output_directory'], 'overlap_matrix.npy'), overlap_matrix)
 
     execution_time = time.time() - start

--- a/ecephys_spike_sorting/modules/kilosort_postprocessing/postprocessing.py
+++ b/ecephys_spike_sorting/modules/kilosort_postprocessing/postprocessing.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from ...common.utils import printProgressBar
 
-def remove_double_counted_spikes(spike_times, spike_clusters, amplitudes, channel_map, templates, pc_features, pc_feature_ind, sample_rate, params, epochs = None):
+def remove_double_counted_spikes(spike_times, spike_clusters, spike_templates, amplitudes, channel_map, templates, pc_features, pc_feature_ind, sample_rate, params, epochs = None):
 
     """ Remove putative double-counted spikes from Kilosort outputs
 
@@ -14,6 +14,8 @@ def remove_double_counted_spikes(spike_times, spike_clusters, amplitudes, channe
         Spike times in samples 
     spike_clusters : numpy.ndarray (num_spikes x 0)
         Cluster IDs for each spike time
+    spike_templates : numpy.ndarray (num_spikes x 0)
+        Template IDs for each spike time
     amplitudes : numpy.ndarray (num_spikes x 0)
         Amplitude value for each spike time
     channel_map : numpy.ndarray (num_units x 0)
@@ -40,6 +42,8 @@ def remove_double_counted_spikes(spike_times, spike_clusters, amplitudes, channe
         Spike times in seconds (same timebase as epochs)
     spike_clusters : numpy.ndarray (num_spikes x 0)
         Cluster IDs for each spike time
+    spike_templates : numpy.ndarray (num_spikes x 0)
+        Template IDs for each spike time
     amplitudes : numpy.ndarray (num_spikes x 0)
         Amplitude value for each spike time
     pc_features : numpy.ndarray (num_spikes x num_pcs x num_channels)
@@ -76,7 +80,12 @@ def remove_double_counted_spikes(spike_times, spike_clusters, amplitudes, channe
 
         spikes_to_remove = np.concatenate((spikes_to_remove, for_unit1[to_remove]))
 
-    spike_times, spike_clusters, amplitudes, pc_features = remove_spikes(spike_times, spike_clusters, amplitudes, pc_features, spikes_to_remove)
+    spike_times, spike_clusters, spike_templates, amplitudes, pc_features = remove_spikes(spike_times, 
+                                                                        spike_clusters, 
+                                                                        spike_templates, 
+                                                                        amplitudes, 
+                                                                        pc_features, 
+                                                                        spikes_to_remove)
 
     print('Removing between-unit overlapping spikes...')
 
@@ -101,13 +110,14 @@ def remove_double_counted_spikes(spike_times, spike_clusters, amplitudes, channe
                 spikes_to_remove = np.concatenate((spikes_to_remove, for_unit1[to_remove1], for_unit2[to_remove2]))
 
 
-    spike_times, spike_clusters, amplitudes, pc_features = remove_spikes(spike_times, 
-                                                                         spike_clusters, 
+    spike_times, spike_clusters, spike_templates, amplitudes, pc_features = remove_spikes(spike_times, 
+                                                                         spike_clusters,
+                                                                         spike_templates, 
                                                                          amplitudes, 
                                                                          pc_features, 
                                                                          np.unique(spikes_to_remove))
 
-    return spike_times, spike_clusters, amplitudes, pc_features, overlap_matrix
+    return spike_times, spike_clusters, spike_templates, amplitudes, pc_features, overlap_matrix
 
                 
 def find_within_unit_overlap(spike_train, overlap_window = 5):
@@ -176,7 +186,7 @@ def find_between_unit_overlap(spike_train1, spike_train2, overlap_window = 5):
     return spikes_to_remove1, spikes_to_remove2
 
 
-def remove_spikes(spike_times, spike_clusters, amplitudes, pc_features, spikes_to_remove):
+def remove_spikes(spike_times, spike_clusters, spike_templates, amplitudes, pc_features, spikes_to_remove):
 
     """
     Removes spikes from Kilosort outputs
@@ -187,6 +197,8 @@ def remove_spikes(spike_times, spike_clusters, amplitudes, pc_features, spikes_t
         Spike times in samples 
     spike_clusters : numpy.ndarray (num_spikes x 0)
         Cluster IDs for each spike time
+    spike_templates : numpy.ndarray (num_spikes x 0)
+        Template IDs for each spike time
     amplitudes : numpy.ndarray (num_spikes x 0)
         Amplitude value for each spike time
     pc_features : numpy.ndarray (num_spikes x num_pcs x num_channels)
@@ -198,6 +210,7 @@ def remove_spikes(spike_times, spike_clusters, amplitudes, pc_features, spikes_t
     --------
     spike_times : numpy.ndarray (num_spikes - spikes_to_remove x 0)
     spike_clusters : numpy.ndarray (num_spikes - spikes_to_remove x 0)
+    spike_templates : numpy.ndarray (num_spikes - spikes_to_remove x 0)
     amplitudes : numpy.ndarray (num_spikes - spikes_to_remove x 0)
     pc_features : numpy.ndarray (num_spikes - spikes_to_remove x num_pcs x num_channels)
 
@@ -205,8 +218,9 @@ def remove_spikes(spike_times, spike_clusters, amplitudes, pc_features, spikes_t
 
     spike_times = np.delete(spike_times, spikes_to_remove, 0)
     spike_clusters = np.delete(spike_clusters, spikes_to_remove, 0)
+    spike_templates = np.delete(spike_templates, spikes_to_remove, 0)
     amplitudes = np.delete(amplitudes, spikes_to_remove, 0)
     pc_features = np.delete(pc_features, spikes_to_remove, 0)
 
-    return spike_times, spike_clusters, amplitudes, pc_features
+    return spike_times, spike_clusters, spike_templates, amplitudes, pc_features
 

--- a/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
@@ -22,7 +22,7 @@ def calculate_mean_waveforms(args):
     rawData = np.memmap(args['ephys_params']['ap_band_file'], dtype='int16', mode='r')
     data = np.reshape(rawData, (int(rawData.size/args['ephys_params']['num_channels']), args['ephys_params']['num_channels']))
 
-    spike_times, spike_clusters, amplitudes, templates, channel_map, clusterIDs, cluster_quality = \
+    spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality = \
             load_kilosort_data(args['directories']['kilosort_output_directory'], \
                 args['ephys_params']['sample_rate'], \
                 convert_to_seconds = False)

--- a/ecephys_spike_sorting/modules/noise_templates/__main__.py
+++ b/ecephys_spike_sorting/modules/noise_templates/__main__.py
@@ -16,7 +16,7 @@ def classify_noise_templates(args):
     
     start = time.time()
 
-    spike_times, spike_clusters, amplitudes, templates, channel_map, cluster_ids, cluster_quality = \
+    spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, cluster_ids, cluster_quality = \
             load_kilosort_data(args['directories']['kilosort_output_directory'], \
                 args['ephys_params']['sample_rate'], \
                 convert_to_seconds = True)

--- a/ecephys_spike_sorting/modules/quality_metrics/__main__.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/__main__.py
@@ -21,7 +21,7 @@ def calculate_quality_metrics(args):
     print("Loading data...")
 
     try:
-        spike_times, spike_clusters, amplitudes, templates, channel_map, clusterIDs, cluster_quality, pc_features, pc_feature_ind = \
+        spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality, pc_features, pc_feature_ind = \
                 load_kilosort_data(args['directories']['kilosort_output_directory'], \
                     args['ephys_params']['sample_rate'], \
                     use_master_clock = False,

--- a/ecephys_spike_sorting/scripts/batch_processing.py
+++ b/ecephys_spike_sorting/scripts/batch_processing.py
@@ -24,10 +24,10 @@ for directory in sorted_directories:
 				#'depth_estimation',
 				##'median_subtraction',
 				#'kilosort_helper',
-				#'kilosort_postprocessing',
-				#'noise_templates',
-				'mean_waveforms'] #,
-				#'quality_metrics']
+				'kilosort_postprocessing',
+				'noise_templates',
+				'mean_waveforms',
+				'quality_metrics']
 
 	for module in modules:
 


### PR DESCRIPTION
Also removes appended "_r" from kilosort_postprocessing output files, so these files can be used by downstream modules.

Closes #37 