### PR TITLE
Updates for Kilosort3 compatibility

### DIFF
--- a/ecephys_spike_sorting/common/utils.py
+++ b/ecephys_spike_sorting/common/utils.py
@@ -278,7 +278,7 @@ def load_kilosort_data(folder,
     amplitudes = load(folder,'amplitudes.npy')
     templates = load(folder,'templates.npy')
     unwhitening_mat = load(folder,'whitening_mat_inv.npy')
-    channel_map = load(folder, 'channel_map.npy')
+    channel_map = np.squeeze(load(folder, 'channel_map.npy'))
 
     if include_pcs:
         pc_features = load(folder, 'pc_features.npy')

--- a/ecephys_spike_sorting/common/utils.py
+++ b/ecephys_spike_sorting/common/utils.py
@@ -191,7 +191,11 @@ def read_cluster_group_tsv(filename):
 
     info = pd.read_csv(filename, sep='\t')
     cluster_ids = info['cluster_id'].values.astype('int')
-    cluster_quality = info['group'].values
+    
+    try:
+        cluster_quality = info['group'].values
+    except KeyError:
+        cluster_quality = info['KSLabel'].values
 
     return cluster_ids, cluster_quality
 

--- a/ecephys_spike_sorting/modules/kilosort_helper/README.md
+++ b/ecephys_spike_sorting/modules/kilosort_helper/README.md
@@ -2,11 +2,11 @@ Kilosort Helper
 ==============
 Python wrapper for Matlab-based spike sorting with Kilosort.
 
-This module auto-generates the channel map, configuration file, and master file for Kilosort, and runs everything via the Matlab engine.
+This module auto-generates the channel map, configuration file, and master file for Kilosort, and runs everything via the Matlab engine for Python.
 
 Dependencies
 ------------
-[Kilosort](https://github.com/MouseLand/Kilosort2) or [Kilosort2](https://github.com/cortex-lab/kilosort) - requires Matlab >=R2016b with Signal Processing and Parallel Computing Toolboxes, Visual Studio Community 2013, and a CUDA-compatible GPU
+Kilosort [v1](https://github.com/cortex-lab/Kilosort), [v2, v2.5, or v3](https://github.com/MouseLand/kilosort) - requires Matlab >=R2016b with Signal Processing and Parallel Computing Toolboxes, Visual Studio Community 2013, and a CUDA-compatible GPU
 [Matlab Engine API for Python](https://www.mathworks.com/help/matlab/matlab_external/install-the-matlab-engine-for-python.html) - this may restrict the Python version you're able to use
 
 Running

--- a/ecephys_spike_sorting/modules/kilosort_helper/__main__.py
+++ b/ecephys_spike_sorting/modules/kilosort_helper/__main__.py
@@ -58,6 +58,14 @@ def run_kilosort(args):
                                              input_file_forward_slash,
                                              args['ephys_params'], 
                                              args['kilosort_helper_params']['kilosort2_params'])
+
+    elif args['kilosort_helper_params']['kilosort_version'] == 3:
+    
+        matlab_file_generator.create_config3(args['kilosort_helper_params']['matlab_home_directory'], 
+                                             output_dir_forward_slash, 
+                                             input_file_forward_slash,
+                                             args['ephys_params'], 
+                                             args['kilosort_helper_params']['kilosort3_params'])
     else:
         return
 
@@ -69,9 +77,12 @@ def run_kilosort(args):
     if args['kilosort_helper_params']['kilosort_version'] == 1:
         eng.kilosort_config_file(nargout=0)
         eng.kilosort_master_file(nargout=0)
-    else:
+    elif args['kilosort_helper_params']['kilosort_version'] == 2: 
         eng.kilosort2_config_file(nargout=0)
         eng.kilosort2_master_file(nargout=0)
+    elif args['kilosort_helper_params']['kilosort_version'] == 3:
+        eng.kilosort3_config_file(nargout=0)
+        eng.main_kilosort3(nargout=0)
 
     execution_time = time.time() - start
 

--- a/ecephys_spike_sorting/modules/kilosort_helper/_schemas.py
+++ b/ecephys_spike_sorting/modules/kilosort_helper/_schemas.py
@@ -40,9 +40,41 @@ class Kilosort2Parameters(DefaultSchema):
     nPCs = Int(required=False, default=3, help='how many PCs to project the spikes into')
     useRAM = Int(required=False, default=0, help='must be 0')
 
+class Kilosort3Parameters(DefaultSchema):
+
+    trange = String(required=False, default='[0 Inf]', help='Time range in seconds to process')
+    fproc = String(required=False, default="fullfile('D:/data/kilosort', 'temp_wh.dat')", help='Processed data file on a fast ssd')
+  
+    chanMap = String(required=False, default="'chanMap.mat'", help='path to channel map .mat file')
+    fshigh = Int(required=False, default=300, help='frequency for high pass filtering')
+    minfr_goodchannels = Float(required=False, default=0.1, help='minimum firing rate on a "good" channel (0 to skip)')
+    Th = String(required=False, default='[9 9]', help='threshold (last pass can be lower')
+    lam = Int(required=False, default=10, help='how important is the amplitude penalty (like in Kilosort1, 0 means not used, 10 is average, 50 is a lot)')
+    AUCsplit = Float(required=False, default=0.8, help='splitting a cluster at the end requires at least this much isolation for each sub-cluster (max = 1)')
+    minFR = Float(required=False, default=1/50., help='minimum spike rate (Hz)')
+    momentum = String(required=False, default='[20 400]', help='number of samples to average over (annealed)')
+    sigmaMask = Int(required=False, default=30, help='spatial constant in um for computing residual variance of spike')
+    ThPre = Int(required=False, default=8, help='threshold crossings for pre-clustering (in PCA projection space)')
+    sig = Int(required=False, default=20)
+    nblocks = Int(required=False, default=5)
+
+    spkTh = Int(required=False, default=-6, help='spike threshold is standard deviations')
+    reorder = Int(required=False, default=1, help='whether to reorder batches for drift correction')
+    nskip = Int(required=False, default=25, help='how many batches to skip for determining spike PCs')
+    GPU = Int(required=False, default=1, help='whether to run this code on an Nvidia GPU')
+    nfilt_factor = Int(required=False, default=4, help='max number of clusters per good channel (even temporary ones)')
+    ntbuff = Int(required=False, default=64, help='samples of symmetrical buffer for whitening and spike detection')
+    NT = String(required=False, default='64*1024 + ops.ntbuff', help='this is the batch size; for GPU should be a multiple of 32 + ntbuff)')
+    whiteningRange = Int(required=False, default=32)
+    nSkipCov = Int(required=False, default=25, help='compute whitening matrix from every Nth batch')
+    scaleproc = Int(required=False, default=200, help='int16 scaling of whitenend data')
+    nPCs = Int(required=False, default=3, help='how many PCs to project the spikes into')
+    useRAM = Int(required=False, default=0, help='must be 0')
+
+
 class KilosortHelperParameters(DefaultSchema):
 
-    kilosort_version = Int(required=True, default=2, help='Kilosort version to use (1 or 2)')
+    kilosort_version = Int(required=True, default=2, help='Kilosort version to use (1, 2, or 3)')
 
     surface_channel_buffer = Int(required=False, default=15, help='Number of channels above brain surface to include in spike sorting')
 
@@ -51,6 +83,8 @@ class KilosortHelperParameters(DefaultSchema):
     
     kilosort_params = Nested(KilosortParameters, required=False, help='Parameters used to auto-generate a Kilosort config file')
     kilosort2_params = Nested(Kilosort2Parameters, required=False, help='Parameters used to auto-generate a Kilosort2 config file')
+    kilosort3_params = Nested(Kilosort3Parameters, required=False, help='Parameters used to auto-generate a Kilosort3 config file')
+
 
 class InputParameters(ArgSchema):
     

--- a/ecephys_spike_sorting/modules/kilosort_helper/matlab_file_generator.py
+++ b/ecephys_spike_sorting/modules/kilosort_helper/matlab_file_generator.py
@@ -24,6 +24,12 @@ def create_config2(kilosort_location,forwardslash_output_file_location,forwardsl
     with open(config_path,"w+") as f:
         f.write(config_string)
 
+def create_config3(kilosort_location,forwardslash_output_file_location,forwardslash_input_file_location, ephys_params, params):
+    config_string = make_config_string2(forwardslash_output_file_location, forwardslash_input_file_location,ephys_params, params)   
+    config_path = os.path.join(kilosort_location,'kilosort3_config_file.m')    
+    with open(config_path,"w+") as f:
+        f.write(config_string)
+
 def make_chanmap_string(EndChan = 384, StartChan = 1, Nchannels = 384, probe_type='3A', MaskChannels = '[ ]'):
     chanmap_string = "map = load('neuropixPhase""" + probe_type + "_kilosortChanMap.mat');"
 

--- a/ecephys_spike_sorting/modules/quality_metrics/__main__.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/__main__.py
@@ -37,7 +37,14 @@ def calculate_quality_metrics(args):
             pc_features = None
             pc_feature_ind = None
 
-        metrics = calculate_metrics(spike_times, spike_clusters, amplitudes, channel_map, pc_features, pc_feature_ind, args['quality_metrics_params'])
+        metrics = calculate_metrics(spike_times, 
+            spike_clusters, 
+            spike_templates,
+            amplitudes, 
+            channel_map, 
+            pc_features, 
+            pc_feature_ind, 
+            args['quality_metrics_params'])
     
     except FileNotFoundError:
         

--- a/ecephys_spike_sorting/modules/quality_metrics/__main__.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/__main__.py
@@ -20,23 +20,33 @@ def calculate_quality_metrics(args):
 
     print("Loading data...")
 
-    #try:
-    spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality, pc_features, pc_feature_ind = \
-            load_kilosort_data(args['directories']['kilosort_output_directory'], \
-                args['ephys_params']['sample_rate'], \
-                use_master_clock = False,
-                include_pcs = True)
+    try:
+        if args['quality_metrics_params']['include_pc_metrics']:
+            spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality, pc_features, pc_feature_ind = \
+                load_kilosort_data(args['directories']['kilosort_output_directory'], \
+                    args['ephys_params']['sample_rate'], \
+                    use_master_clock = False,
+                    include_pcs = True)
+        else:
+            spike_times, spike_clusters, spike_templates, amplitudes, templates, channel_map, clusterIDs, cluster_quality = \
+                load_kilosort_data(args['directories']['kilosort_output_directory'], \
+                    args['ephys_params']['sample_rate'], \
+                    use_master_clock = False,
+                    include_pcs = False)
 
-    metrics = calculate_metrics(spike_times, spike_clusters, spike_templates, amplitudes, channel_map, pc_features, pc_feature_ind, args['quality_metrics_params'])
+            pc_features = None
+            pc_feature_ind = None
 
-    #except FileNotFoundError:
+        metrics = calculate_metrics(spike_times, spike_clusters, amplitudes, channel_map, pc_features, pc_feature_ind, args['quality_metrics_params'])
+    
+    except FileNotFoundError:
         
-    #    execution_time = time.time() - start
+        execution_time = time.time() - start
 
-    #    print(" Files not available.")
+        print(" Files not available.")
 
-     #   return {"execution_time" : execution_time,
-     #       "quality_metrics_output_file" : None} 
+        return {"execution_time" : execution_time,
+            "quality_metrics_output_file" : None} 
 
     output_file = args['quality_metrics_params']['quality_metrics_output_file']
 

--- a/ecephys_spike_sorting/modules/quality_metrics/_schemas.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/_schemas.py
@@ -18,6 +18,9 @@ class QualityMetricsParams(DefaultSchema):
 
     quality_metrics_output_file = String(required=True, help='CSV file where metrics will be saved')
 
+    include_pc_metrics = Boolean(required=False, default=True, help='Compute features that require principal components')
+
+
 class InputParameters(ArgSchema):
     
     quality_metrics_params = Nested(QualityMetricsParams)

--- a/ecephys_spike_sorting/modules/quality_metrics/_schemas.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/_schemas.py
@@ -1,10 +1,11 @@
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
-from argschema.fields import Nested, InputDir, String, Float, Dict, Int
+from argschema.fields import Nested, InputDir, String, Float, Dict, Int, Bool
 from ...common.schemas import EphysParams, Directories, WaveformMetricsFile
 
 
 class QualityMetricsParams(DefaultSchema):
+    
     isi_threshold = Float(required=False, default=0.0015, help='Maximum time (in seconds) for ISI violation')
     min_isi = Float(required=False, default=0.00, help='Minimum time (in seconds) for ISI violation')
     num_channels_to_compare = Int(required=False, default=13, help='Number of channels to use for computing PC metrics; must be odd')
@@ -18,7 +19,7 @@ class QualityMetricsParams(DefaultSchema):
 
     quality_metrics_output_file = String(required=True, help='CSV file where metrics will be saved')
 
-    include_pc_metrics = Boolean(required=False, default=True, help='Compute features that require principal components')
+    include_pc_metrics = Bool(required=False, default=True, help='Compute features that require principal components')
 
 
 class InputParameters(ArgSchema):
@@ -29,6 +30,7 @@ class InputParameters(ArgSchema):
     waveform_metrics = Nested(WaveformMetricsFile)
     
 class OutputSchema(DefaultSchema): 
+
     input_parameters = Nested(InputParameters, 
                               description=("Input parameters the module " 
                                            "was run with"), 

--- a/ecephys_spike_sorting/scripts/create_input_json.py
+++ b/ecephys_spike_sorting/scripts/create_input_json.py
@@ -140,6 +140,22 @@ def createInputJson(output_file,
                 "momentum" : '[20 400]',
                 "sigmaMask" : 30,
                 "ThPre" : 8
+            },
+            
+            "kilosort3_params" :
+            {
+                "chanMap" : "'chanMap.mat'",
+                "fshigh" : 300,
+                "minfr_goodchannels" : 0.1,
+                "Th" : '[9 9]',
+                "lam" : 10,
+                "AUCsplit" : 0.8,
+                "minFR" : 1/50.,
+                "momentum" : '[20 400]',
+                "sigmaMask" : 30,
+                "ThPre" : 8,
+                "sig" : 20,
+                "nblocks" : 5
             }
         },
 

--- a/ecephys_spike_sorting/scripts/create_input_json.py
+++ b/ecephys_spike_sorting/scripts/create_input_json.py
@@ -192,7 +192,7 @@ def createInputJson(output_file,
             'n_silhouette' : 10000,
             "quality_metrics_output_file" : os.path.join(kilosort_output_directory, "metrics_test.csv"),
             "drift_metrics_interval_s" : 51,
-            "drift_metrics_min_spikes_per_interval" : 10
+            "drift_metrics_min_spikes_per_interval" : 10,
 
             "include_pc_metrics" : True
         }

--- a/ecephys_spike_sorting/scripts/create_input_json.py
+++ b/ecephys_spike_sorting/scripts/create_input_json.py
@@ -141,7 +141,7 @@ def createInputJson(output_file,
                 "sigmaMask" : 30,
                 "ThPre" : 8
             },
-            
+
             "kilosort3_params" :
             {
                 "chanMap" : "'chanMap.mat'",
@@ -193,6 +193,8 @@ def createInputJson(output_file,
             "quality_metrics_output_file" : os.path.join(kilosort_output_directory, "metrics_test.csv"),
             "drift_metrics_interval_s" : 51,
             "drift_metrics_min_spikes_per_interval" : 10
+
+            "include_pc_metrics" : True
         }
 
     }


### PR DESCRIPTION
* Squeeze `channel_map.npy` array on load (closes #55)
* Include KS3 parameters in `create_input_json.py`
* Load cluster quality from `KSLabel` column if `group` column fails
* Add option to ignore PC-based metrics when `pc_features.npy` is not available (see [this issue](https://github.com/MouseLand/Kilosort/issues/317) for more details)