### PR TITLE
Allen internal pipeline

### DIFF
--- a/ecephys_spike_sorting/scripts/helpers/check_data_processing.py
+++ b/ecephys_spike_sorting/scripts/helpers/check_data_processing.py
@@ -163,7 +163,8 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
     missing_backup_list = []
     for file in data_files:
         if file not in backup_size_dict:
-            missing_backup_list.append(file)
+            if not(file =="ap_timestamps.npy"):
+                missing_backup_list.append(file)
     if missing_backup_list:
         print('ERROR: Some files are not backed up for '+probe+':')
         print(missing_backup_list)
@@ -249,10 +250,13 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
                     new_path = os.path.join(new_dir, filename)
                     #print(new_path)
                     copy_not_move = ('probe_depth' in keep_file) or ('probe_info' in keep_file)
-                    if copy_not_move and cortex_only:
-                        shutil.copy2(local_path, new_path)
-                    else:
-                        shutil.move(local_path, new_path)
+                    try:
+                        if copy_not_move and cortex_only:
+                            shutil.copy2(local_path, new_path)
+                        else:
+                            shutil.move(local_path, new_path)
+                    except Exception as E:
+                        logging.error('Failed to move phy file '+keep_file+' to subdir', exc_info=True)
             except Exception as E:
                 logging.error('Failed to move phy files to subdir', exc_info=True)
 

--- a/ecephys_spike_sorting/scripts/helpers/check_data_processing.py
+++ b/ecephys_spike_sorting/scripts/helpers/check_data_processing.py
@@ -124,7 +124,9 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
             pass
 
         if not found:
-            missing_files_list.append(data_file)
+            #putting this conditional here because sometimes (maybe certin installs? only NP2?) don't overwrite this file but the others do
+            if not(data_file =="ap_timestamps.npy"):
+                missing_files_list.append(data_file)
 
     if missing_files_list:
         print('ERROR: Some processing files were not found on any drive for '+probe)
@@ -484,6 +486,7 @@ def make_files(probe_type):
           "probe_info.json":data_file_params('empty',True,'depth_estimation'),
           "channel_states.npy":data_file_params('events',True,'extraction'),
           "event_timestamps.npy":data_file_params('events',True,'extraction'),
+          "ap_timestamps.npy":data_file_params('spikes',False,'extraction'),
           #r"continuous\Neuropix-{}-100.1\continuous.dat".format(probe_type):data_file_params('empty',True,'extraction'),
           "continuous.dat":data_file_params('lfp',True,'extraction'),
           "lfp_timestamps.npy":data_file_params('lfp',True,'extraction'),


### PR DESCRIPTION
added flexible handling of the ap_timestamps file which sometimes seems to get overwritten by kilosort but not on NP2