### PR TITLE
Allen internal pipeline

### DIFF
--- a/ecephys_spike_sorting/scripts/cortex_from_extraction.py
+++ b/ecephys_spike_sorting/scripts/cortex_from_extraction.py
@@ -62,6 +62,7 @@ final_copy_all_parallel = [
 #     },
 #    }
 
+sharing_backup = True
 
 if __name__ == '__main__':
   try:
@@ -76,7 +77,8 @@ if __name__ == '__main__':
     copy_while_waiting_modules=copy_while_waiting_modules,
     final_copy_all_parallel=final_copy_all_parallel,
     start_module = start_module,
-    end_module = end_module
+    end_module = end_module,
+    sharing_backup = sharing_backup
     )
   processor.start_processing()
 

--- a/ecephys_spike_sorting/scripts/helpers/check_data_processing.py
+++ b/ecephys_spike_sorting/scripts/helpers/check_data_processing.py
@@ -86,7 +86,7 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
             print('ERROR: the raw data backup does not match the acquired data for '+probe)
     else:
         err_str = 'WARNING: could not find the acquired data at '+ str(npx_directory) + ' to compare to backup size'
-        print(err_str)
+        #print(err_str)
 
 
     missing_files_list = []
@@ -376,8 +376,9 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
             if f not in data_files and not(f == 'continuous.dat'):
                 extra_files.append(f)
     if extra_files:
-        print("ERROR: Some extra files were found for ",probe)
-        print(extra_files)
+        pass
+        #print("ERROR: Some extra files were found for ",probe)
+        #print(extra_files)
     else:
         pass
         #print("No extra files were found for ", probe)
@@ -391,15 +392,17 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
         else:
             print("ERROR: The raw data on SD4 is not the same size as the raw data on the backup drive for ", probe)
     else:
-        print('ERROR: Could not find raw data on SD4 for  for '+probe+':')
+        pass
+        #print('ERROR: Could not find raw data on SD4 for  for '+probe+':')
 
     missing_net_backup_list = []
     for file in data_files:
         if file not in network_size_dict:
             missing_net_backup_list.append(file)
     if missing_net_backup_list:
-        print('ERROR: Some files are not backed up on SD4 for '+probe+':')
-        print(missing_net_backup_list)
+        pass
+        #print('ERROR: Some files are not backed up on SD4 for '+probe+':')
+        #print(missing_net_backup_list)
     else:
         pass#print('all files are backed up on SD4 for '+probe)
 
@@ -412,11 +415,12 @@ def check_data_processing(probe_type, npx_directory, local_sort_dir, raw_backup_
         print('ERROR: Some processing files have different sizes or modification times on the backup drive and SD4 for '+probe)
         print(net_mismatch_size_list)
     elif not(network_size_dict):
-        print('WARNING: Could not check file sizes on SD4 since they do not exist')
+        pass
+        #print('WARNING: Could not check file sizes on SD4 since they do not exist')
     else:
         pass
         #print('All files on the backup drive match the size and modification times of those on SD4 for '+probe)
-    return sucess
+    return sucess, missing_files_list, mismatch_size_list, missing_backup_list
 
 def safe_delete_npx(local_npx_dir, backup_npx_dir):
     for root, dirs, files in os.walk(local_npx_dir):
@@ -537,10 +541,18 @@ def check_all_data(npx_directories):
 def check_all_space(npx_directories):
     space_dict = {}
     for npx_dir in npx_directories:
-        drive, tail = os.path.splitdrive(npx_dir)
-        free_space = psutil.disk_usage(drive).free
-        if  free_space < (200*(10**9)):
-            space_dict[drive] = free_space
+        #drive, tail = os.path.splitdrive(npx_dir)
+        try:
+            #print(npx_dir)
+            free_space = psutil.disk_usage(npx_dir).free
+            if  free_space < (600*(10**9)):
+                space_dict[drive] = free_space
+        except Exception as E:
+            npx_dir = os.path.split(npx_dir)[0]
+            #print(npx_dir)
+            free_space = psutil.disk_usage(npx_dir).free
+            if  free_space < (600*(10**9)):
+                space_dict[drive] = free_space
     if space_dict:
         for drive in space_dict.items():
             print("ERROR: Not enough space on ",drive,"for acquisition")

--- a/ecephys_spike_sorting/scripts/resort_from_kilosort.bat
+++ b/ecephys_spike_sorting/scripts/resort_from_kilosort.bat
@@ -3,7 +3,7 @@ title Sorting using resort_from_kilosort.py and an input session name
 ECHO navigating to code directory
 cd C:\Users\svc_neuropix\Documents\GitHub\ecephys_spike_sorting
 ECHO THIS SCRIPT PROCESSES 3 PROBES, YOU MUST ALSO START PROCESSING ON THE OTHER PROCESSING COMPUTER
-set /p session_name=Full session name from EXPERIMENT DAY 1 (plus optional args - [-p PROBES, -ctx]): 
+set /p session_name=Full session name from EXPERIMENT DAY 1 (plus optional args - [-p PROBES]): 
 ECHO activating environment and starting ecephys_spike_sorting\scripts\resort_from_kilosort.py
 pipenv run python ecephys_spike_sorting\scripts\resort_from_kilosort.py %session_name%
 cmd \k

--- a/ecephys_spike_sorting/scripts/resort_from_module.bat
+++ b/ecephys_spike_sorting/scripts/resort_from_module.bat
@@ -3,7 +3,7 @@ title Sorting using resort_from_module.py
 ECHO navigating to code directory
 cd C:\Users\svc_neuropix\Documents\GitHub\ecephys_spike_sorting
 ECHO THIS SCRIPT PROCESSES 3 PROBES, YOU MUST ALSO START PROCESSING ON THE OTHER PROCESSING COMPUTER
-set /p session_name=Full session name from EXPERIMENT DAY 1 (plus optional args - [-p PROBES, -ctx, -start]): 
+set /p session_name=Full session name from EXPERIMENT DAY 1 (plus optional args - [-p PROBES, -ctx, -f, -start start_module]): 
 ECHO activating environment and starting ecephys_spike_sorting\scripts\resort_from_module.py
 pipenv run python ecephys_spike_sorting\scripts\resort_from_module.py %session_name%
 cmd \k

--- a/ecephys_spike_sorting/scripts/resort_from_module.py
+++ b/ecephys_spike_sorting/scripts/resort_from_module.py
@@ -1,5 +1,5 @@
 
-from helpers.batch_processing_common_sm_cortex import processing_session
+from helpers.batch_processing_common import processing_session
 from helpers.batch_processing_config import get_from_config, get_from_kwargs
 import sys
 
@@ -24,6 +24,7 @@ modules = [
    'restructure_directories',
    'depth_estimation',
    'median_subtraction',
+   'extend_short_data',
    'kilosort_helper',
    'noise_templates',
    'mean_waveforms',
@@ -80,6 +81,9 @@ if __name__ == '__main__':
   parser.add_argument("-start", "--start_module", 
                   help= "which module to start from")
 
+  parser.add_argument("-f", "--force", 
+                  help= "ignore errors when checking if there is enough space to complete processing", action="store_true")
+
   args = parser.parse_args()
 
   try:
@@ -100,6 +104,9 @@ if __name__ == '__main__':
   cortex_only = args.cortex
   print("cortex only", cortex_only)
 
+  force = args.force
+  print("Force? ignore errors when checking if there is enough space: ", force)
+
   try:
     if not(args.start_module is None):
       start_module = args.start_module
@@ -118,7 +125,8 @@ if __name__ == '__main__':
         final_copy_all_parallel=final_copy_all_parallel,
     start_module = start_module,
     end_module = end_module,
-    processable_probes = probes_in
+    processable_probes = probes_in,
+    force = force
     )
   processor.start_processing()
 

--- a/ecephys_spike_sorting/scripts/sm_cortex_from_kilosort.py
+++ b/ecephys_spike_sorting/scripts/sm_cortex_from_kilosort.py
@@ -8,7 +8,7 @@ import argparse
 
 session_name = '2053709239_532246_20200930'#test_2019-07-25_18-16-48' #Fill in with appropriate session name
 probes_in = ['B']
-cortex_only = False
+cortex_only = True
 
 start_module = 'kilosort_helper'
 end_module = 'cleanup'

--- a/ecephys_spike_sorting/scripts/two_sessions_full_from_kilosort.py
+++ b/ecephys_spike_sorting/scripts/two_sessions_full_from_kilosort.py
@@ -66,7 +66,7 @@ final_copy_all_parallel = [
 #       },
 #    }
         
-
+sharing_backup = True
         
 
 def make_slots(session_names):
@@ -125,6 +125,7 @@ if __name__ == '__main__':
     end_module = end_module,
     probes=probes,
     pxi_slots = slots,
+    sharing_backup = sharing_backup
     )
   processor.start_processing()
 


### PR DESCRIPTION
Lots of bug fixes and enhancements:
found the bug that was preventing ANY checking of space on the backup drive. Small typo meant it was only checking SD8 and D drive
Added a feature so that it doubles the size estimated needed for both D and backups if the "sharing_backups" parameter is true. 
this is on for WED, THURS, FRI and off for everythign else 
everything else should still check just not double
added a force flag to "resort from module" 
if you pass it -f (the same way you would -ctx) then it will ignore any errors found when checking for space and try to sort anyway
changed the params from the default so robocopy only tries 3x over the course of 30seconds instead of trying 1 MILLION TIMES
changed it so that robocopy does not cache the files in memory (might make it a bit faster)
removed the unnecessary pings at the end - it should end by printing whether sorting was successful, and checking if there is space on the ACQ
added features for compatibility with short sorts (probe depth tries to use fewer iterations if it failes and concatenates data to itself thats shorter than 20 minutes so kilosrt doesn't fail)
added what I think will be better error handling if probe_depth fails and probe_info.json doesn't get created
changed cleanup so it doesn't print a bunch of extra stuff, and so the processing script can actually print files that need attention
I removed an unecessary check that caused it to wait 14 hours to cleanup (to avoid deleting data that might not have gone to lims yet)