### PR TITLE
bug fix for waveform metrics and quality metrics

### DIFF
--- a/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
@@ -31,6 +31,7 @@ def calculate_mean_waveforms(args):
 
     waveforms, spike_counts, coords, labels, metrics = extract_waveforms(data, spike_times, \
                 spike_clusters,
+                spike_templates,
                 templates,
                 channel_map,
                 args['ephys_params']['bit_volts'], \

--- a/ecephys_spike_sorting/modules/mean_waveforms/extract_waveforms.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/extract_waveforms.py
@@ -125,7 +125,7 @@ def extract_waveforms(raw_data,
                         waveforms[wv_idx, :, :] = rawWaveform * bit_volts
 
                 # concatenate to existing dataframe
-                target_template_id = spike_templates[np.where(spike_clusters == cluster_idx)[0][0]] + 1
+                target_template_id = spike_templates[np.where(spike_clusters == cluster_idx)[0][0]]
                 metrics = pd.concat([metrics, calculate_waveform_metrics(waveforms[:total_waveforms, :, :],
                                                                          cluster_id, 
                                                                          peak_channels[target_template_id], 

--- a/ecephys_spike_sorting/modules/mean_waveforms/extract_waveforms.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/extract_waveforms.py
@@ -14,6 +14,7 @@ from ...common.utils import printProgressBar
 def extract_waveforms(raw_data, 
                       spike_times, 
                       spike_clusters, 
+                      spike_templates,
                       templates, 
                       channel_map, 
                       bit_volts, 
@@ -30,6 +31,7 @@ def extract_waveforms(raw_data,
     raw_data : continuous data as numpy array (samples x channels)
     spike_times : spike times (in samples)
     spike_clusters : cluster IDs for each spike time []
+    spike_template : template IDs for each spike time []
     clusterIDs : all unique cluster ids
     cluster_quality : 'noise' or 'good'
     sample_rate : Hz
@@ -123,9 +125,10 @@ def extract_waveforms(raw_data,
                         waveforms[wv_idx, :, :] = rawWaveform * bit_volts
 
                 # concatenate to existing dataframe
+                target_template_id = spike_templates[np.where(spike_clusters == cluster_idx)[0][0]] + 1
                 metrics = pd.concat([metrics, calculate_waveform_metrics(waveforms[:total_waveforms, :, :],
                                                                          cluster_id, 
-                                                                         peak_channels[cluster_idx], 
+                                                                         peak_channels[target_template_id], 
                                                                          channel_map,
                                                                          sample_rate, 
                                                                          upsampling_factor,

--- a/ecephys_spike_sorting/modules/quality_metrics/metrics.py
+++ b/ecephys_spike_sorting/modules/quality_metrics/metrics.py
@@ -675,7 +675,7 @@ def presence_ratio(spike_train, min_time, max_time, num_bins=100):
 
     h, b = np.histogram(spike_train, np.linspace(min_time, max_time, num_bins))
 
-    return np.sum(h > 0) / num_bins
+    return np.sum(h > 0) / (num_bins - 1)
 
 
 def firing_rate(spike_train, min_time = None, max_time = None):


### PR DESCRIPTION
for waveform metrics:

-  support manual curation: after manual curation, template_idx is not equal to cluster_idx, so we need to check from spike_templates to see the lastest rematched template_idx

for quality metrics:
- fix a bug in calculating presense ratio. remove one edge so that we have equal number of bins and edges, the max will be 1 (not 0.99 as before)